### PR TITLE
Patch 1

### DIFF
--- a/PacketLogger_API.au3
+++ b/PacketLogger_API.au3
@@ -77,6 +77,11 @@ EndFunc
 
 Func PacketLogger_Handle($Socket, $ReceiveCallback, $MaxReceiveBytes = 8192)
 	$ReceivedPacket = TCPRecv($Socket, $MaxReceiveBytes)
+	If @extended = 1 Then ; Return 1 to sleep if no data were received
+		Return 1
+	elseIf @error <> 0 Then ;Return 2 so the "thread" for connected client can end
+		Return 2
+	Endif
 	;If @error <> 0 Then
 	;	MsgBox(0,"",@error)
 	;	If IsFunc($PacketLogger_DisconnectedCallback) Then

--- a/main.au3
+++ b/main.au3
@@ -76,9 +76,12 @@ Func Bot()
     WEnd
 
     ;Main bot loop
+    local $res = 0
     While $fishing
-        Sleep(10)
-        PacketLogger_Handle($Socket, IncomingPacket)
+        $res = PacketLogger_Handle($Socket, IncomingPacket)
+		
+		If($res = 1) Then sleep(50)
+	    If($res = 2) then ExitLoop
     WEnd
 
     PacketLogger_Close($Socket)


### PR DESCRIPTION
Better sleep in Bot -> MainLoop so the thread sleeps only when no data were received and exits if an error is returned (client turned off). 
The sleep could be moved into PacketLogger API to avoid further testing in the main loop.